### PR TITLE
[PCF-600] Adapt docker container name to new dks naming

### DIFF
--- a/shared/cypress/support/db.sh
+++ b/shared/cypress/support/db.sh
@@ -6,4 +6,4 @@ DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
 
 SQL_RESET_CMD=$(cat "$DIR/$OPERATION"-db-backup.sh);
 
-docker exec fc_pg-"$APP"_1 bash -c "$SQL_RESET_CMD"
+docker exec pc-pg-"$APP"-1 bash -c "$SQL_RESET_CMD"

--- a/shared/cypress/support/get-user-activation-token.sh
+++ b/shared/cypress/support/get-user-activation-token.sh
@@ -5,4 +5,4 @@ USERNAME=$2
 
 TOKEN_CMD="psql -x pg-db -U pg-user -c \"SELECT token FROM \\\"user\\\" WHERE username='$2' LIMIT 1;\"";
 
-docker exec fc_pg-"$APP"_1 bash -c "${TOKEN_CMD/'$1'/$USERNAME} | tail -n 2 | head -n 1 | cut -d' ' -f3 | tr -d '\n'";
+docker exec pc-pg-"$APP"-1 bash -c "${TOKEN_CMD/'$1'/$USERNAME} | tail -n 2 | head -n 1 | cut -d' ' -f3 | tr -d '\n'";


### PR DESCRIPTION
The containers names has been changed in federation.

Federation needs federation-admin to start the medium stack and launch the e2e tests.

In this PR, I adapt the names of the container with the new dks conventions:

fc_pg-exploitation-fca_1 becomes pc-pg-exploitation-fca-1