### PR TITLE
Upgrade Docker Compose to fix CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,10 +56,11 @@ jobs:
       - name: Set up dockerx
         uses: docker/setup-buildx-action@v2
 
-      - name: Set up Docker BuildKit
-        run: |
-          export DOCKER_BUILDKIT=1
-          export COMPOSE_BAKE=true
+      # Workaround for https://github.com/docker/compose/issues/12892 
+      - name: Upgrade Docker Compose
+        uses: docker/setup-compose-action@v1
+        with:
+          version: latest
 
       - name: Set up Node.js for federation-admin
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Problem

The latest GitHub Actions runner image includes Docker Compose 2.32.0, which fails to build required images for dependent services.

## Proposed solution

Add a step to upgrade Docker Compose to the latest version, which does not have this bug.

Note that the replaced step that ran two `export` commands had no effect since variables exported in a shell one step are not persistent for subsequent steps (you have to append them to `$GITHUB_ENV`).